### PR TITLE
Fix NoSuchFieldException on <=ICS

### DIFF
--- a/androidpagecontrol/src/main/kotlin/com/androidpagecontrol/PageControl.kt
+++ b/androidpagecontrol/src/main/kotlin/com/androidpagecontrol/PageControl.kt
@@ -207,7 +207,7 @@ open class PageControl(context: Context, attrs: AttributeSet) : LinearLayout(con
         var statesDefault = IntArray(1)
         statesDefault.set(0, -android.R.attr.state_pressed)
         sld.addState(statesDefault, drawableDefault)
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
+        if (Build.VERSION.SDK_INT < 16) {
             b.setBackgroundDrawable(sld)
         } else {
             b.setBackground(sld)


### PR DESCRIPTION
kotlin has problems with inlining constants properly -> use numerical value
